### PR TITLE
Circumvent crash if 'git describe' fails

### DIFF
--- a/python_scripts/version.py
+++ b/python_scripts/version.py
@@ -11,6 +11,9 @@ def analysis_version_string():
     # assuming it is in the git repository
     old_dir = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    version_string = subprocess.check_output(["git", "describe"]).rstrip('\n')
+    try:
+        version_string = subprocess.check_output(["git", "describe"]).rstrip('\n')
+    except:
+        version_string = 'SMASHana - unknown version'
     os.chdir(old_dir)
     return version_string

--- a/python_scripts/version.py
+++ b/python_scripts/version.py
@@ -13,7 +13,7 @@ def analysis_version_string():
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     try:
         version_string = subprocess.check_output(["git", "describe"]).rstrip('\n')
-    except:
+    except subprocess.CalledProcessError:
         version_string = 'SMASHana - unknown version'
     os.chdir(old_dir)
     return version_string


### PR DESCRIPTION
* Git describe only works once there was a first tag.
* In case the analysis suite is downloaded and not cloned, the history
is not loaded, meaning tags are not loaded either.
* Therefore, 'git describes' which is used to determine the SMASHana
version, fails
* Fixed the crash by catching an exception and alternatively returning
an unknown version.

Fixes #15