### PR TITLE
Fix impact parameter sampling for dileptons in AgAg

### DIFF
--- a/test/dileptons/AgAg/config.yaml
+++ b/test/dileptons/AgAg/config.yaml
@@ -21,7 +21,6 @@ Modi:
     Collider:
         Impact:
             # HADES 0-40%
-            Sample: "uniform"
             Range: [0.0, 7.7]
         Projectile:
             Particles: {2212: 47, 2112: 61} # Silver


### PR DESCRIPTION
Should be the default, which is `quadratic`.