### PR TITLE
Add detailed balance for stochastic 3-to-1 reactions

### DIFF
--- a/test/detailed_balance/CMakeLists.txt
+++ b/test/detailed_balance/CMakeLists.txt
@@ -240,6 +240,12 @@ one_balance_test("pi_rho_f2"
     "300.0"
 )
 
+one_balance_test("pi3_omega"
+    "π⁰,π⁺,π⁻,ω"
+    "π⁰,π⁺,π⁻:ω"
+    "120.0"
+)
+
 ########## baryonic boxes ##########
 
 # N-pi-Delta, 1 <--> 2 reactions only (Delta <--> pi + N)

--- a/test/detailed_balance/pi3_omega/config.yaml
+++ b/test/detailed_balance/pi3_omega/config.yaml
@@ -1,0 +1,42 @@
+Version: 1.8
+
+Logging:
+  default: WARN
+
+General:
+    Modus:         Box
+    Delta_Time:    0.01
+    End_Time:      150.0
+    Randomseed:    -1
+    Testparticles: 1
+    Nevents:       2
+
+Output:
+    Output_Interval:  1.0
+    Collisions:
+        Format:  ["Binary"]
+        Print_Start_End:    False
+    Particles:
+        Format:  ["Binary"]
+        Only_Final:         No
+
+
+Collision_Term:
+    Force_Decays_At_End:     False
+    Strings:                 False
+    Collision_Criterion:     Stochastic
+    Include_Stochastic_3to1: True
+
+
+Modi:
+    Box:
+        Length: 10.0
+        Temperature: 0.3
+        Initial_Condition: "thermal momenta"
+        Start_Time:    0.0
+
+        Init_Multiplicities:
+          223: 200
+          # 111:    200
+          # 211:    200
+          # -211:   200

--- a/test/detailed_balance/pi3_omega/decaymodes.txt
+++ b/test/detailed_balance/pi3_omega/decaymodes.txt
@@ -1,0 +1,12 @@
+# Format of this file:
+# anything after a # is a comment and will be ignored
+# The decays for a given particle are given as:
+# <name of decaying particle>
+# <branching ratio> <angular momentum L> <names of decay products>
+# <branching ratio> <angular momentum L> <names of decay products>
+# ...
+
+#################### non-strange mesons ####################
+
+ω
+0.893   1  π⁺ π⁻ π⁰

--- a/test/detailed_balance/pi3_omega/particles.txt
+++ b/test/detailed_balance/pi3_omega/particles.txt
@@ -1,0 +1,6 @@
+# NAME MASS[GEV] WIDTH[GEV] PARITY PDG
+
+########## unflavored mesons ##########
+
+π               0.138   7.7e-9    -      111     211
+ω               0.783   8.49e-3   -      223


### PR DESCRIPTION
It probes the 3pi-to-omega back-reaction of the 1-to-3 decay via the 
stochastic criterion.

Ready for merge when 3-to-1 reactions are implemented into SMASH with the next public release.