### PR TITLE
Extend the particle name extraction for the STAR data files.

### DIFF
--- a/test/energy_scan/mult_and_spectra_plotter.py
+++ b/test/energy_scan/mult_and_spectra_plotter.py
@@ -309,7 +309,8 @@ class DataTree:
                 'antiomega' : -3334,
             }
             for part_name in name_to_pdg.keys():
-                if part_name == exp_file.split('/')[-1].split('.')[0].split('_')[-1]:
+                if (part_name == exp_file.split('/')[-1].split('_cent')[0].split('_')[-1] or
+                    part_name == exp_file.split('/')[-1].split('.')[0].split('_')[-1]):
                     break
 
             pdg = name_to_pdg[part_name]


### PR DESCRIPTION
This is a fix for #34 .
I included another check if the file of experimental data follows the name convention of the files generated from STAR data.
I attach some plots which show that the experimental data is now plotted correctly.
[mtspectra_AuAuPbPb_SPS_2212.pdf](https://github.com/smash-transport/smash-analysis/files/6419796/mtspectra_AuAuPbPb_SPS_2212.pdf)
[mtspectra_AuAuPbPb_RHIC_LHC_211.pdf](https://github.com/smash-transport/smash-analysis/files/6419799/mtspectra_AuAuPbPb_RHIC_LHC_211.pdf)
[mtspectra_AuAuPbPb_RHIC_LHC_321.pdf](https://github.com/smash-transport/smash-analysis/files/6419800/mtspectra_AuAuPbPb_RHIC_LHC_321.pdf)


