### PR TITLE
Added NO_DEFAULT_PATH when searching SMASH executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ find_python_module(argparse VERSION 1.1 REQUIRED)
 find_python_module(yaml VERSION 3.11 REQUIRED)
 find_python_module(pandas VERSION 0.14.1 REQUIRED)
 
-find_program(SMASH smash PATHS ${SMASH_PATH})
+find_program(SMASH smash PATHS ${SMASH_PATH} NO_DEFAULT_PATH)
 if(NOT SMASH)
     message(FATAL_ERROR
         "SMASH not found. Please specify a path to the SMASH build directory "


### PR DESCRIPTION
Related to #36 .
It just adds NO_DEFAULT_PATH in CMakeLists.txt when searching the smash executable, so that a local self compiled version (e.g. to test a new branch) can be chosen instead of the default one provided by the container.