### PR TITLE
Reduce grid cell length for stochastic to match geometric criterion

### DIFF
--- a/test/elastic_box/CMakeLists.txt
+++ b/test/elastic_box/CMakeLists.txt
@@ -19,9 +19,10 @@ function(run_one_test
     set(i 0)
     set(multipl_opt "Modi: {Box: {Init_Multiplicities: {111: 200}}}")
     # The cell length is explicitly reduced for the stochastic criterion below
-    # to match the geometric criterion case, where the maximum cross section is
-    # automatically set as the elastic cross section for elastic boxes.
-    set(stoch_crit_opt "Collision_Term: {Collision_Criterion: Stochastic}, Collision_Term: {Fixed_Min_Cell_Length: 0.6}")
+    # such that 2x2x2 grid fits into all box sizes that are tested. This is
+    # also closer to the geometric case (where the maximum cross section is
+    # automatically set to the elastic cross section).
+    set(stoch_crit_opt "Collision_Term: {Collision_Criterion: Stochastic}, Collision_Term: {Fixed_Min_Cell_Length: 1.5}")
     set(geom_crit_opt "Collision_Term: {Collision_Criterion: Geometric}")
     set(data_files "")
     foreach(X IN LISTS var_list)

--- a/test/elastic_box/CMakeLists.txt
+++ b/test/elastic_box/CMakeLists.txt
@@ -18,7 +18,10 @@ function(run_one_test
     # run SMASH for both collision criteria
     set(i 0)
     set(multipl_opt "Modi: {Box: {Init_Multiplicities: {111: 200}}}")
-    set(stoch_crit_opt "Collision_Term: {Collision_Criterion: Stochastic}")
+    # The cell length is explicitly reduced for the stochastic criterion below
+    # to match the geometric criterion case, where the maximum cross section is
+    # automatically set as the elastic cross section for elastic boxes.
+    set(stoch_crit_opt "Collision_Term: {Collision_Criterion: Stochastic}, Collision_Term: {Fixed_Min_Cell_Length: 0.6}")
     set(geom_crit_opt "Collision_Term: {Collision_Criterion: Geometric}")
     set(data_files "")
     foreach(X IN LISTS var_list)


### PR DESCRIPTION
This fixes crashes of the elastic box test for low volumes 
(elastic_box_scatrate_vs_V_sims target) and makes the different criteria 
runs more consistent.

The matching is not exact, but only roughly the chosen to be the same.