### PR TITLE
Add dilepton analysis of direct N(1520) Dalitz dilepton decay

### DIFF
--- a/test/dileptons/decaymodes.txt
+++ b/test/dileptons/decaymodes.txt
@@ -356,7 +356,9 @@ N(1520)
 0.65   2  N π  # 55 - 65 %
 0.15   0  Δ π  # 15 - 23 %
 0.07   2  Δ π  #  7 - 11 %
-0.11   0  N ρ  # serves as proxy for N(1520) dilepton Dalitz decay
+0.11   0  N ρ  # proxy for N(1520) dilepton Dalitz decay
+#0.11  0  e⁻ e⁺ N⁺  # alternative direct treatment of N(1520) dilepton Dalitz
+#0.11  0  e⁻ e⁺ N⁰  # comment out N ρ proxy when using (constant form factor)
 0.02   1  N σ  #     < 2 %
 
 N(1535)

--- a/test/dileptons/definitions.py
+++ b/test/dileptons/definitions.py
@@ -45,13 +45,13 @@ hist_arr_dim = {"channel": 0,
 
 ### CHANNEL NUMBERING ###
 
-n_channels = 11  # 10 known + 1 for potential unknown sources (should be zero)
+n_channels = 12  # 11 known + 1 for potential unknown sources (should be zero)
 
 direct_channels = {
     113:  0,  # rho
     223:  1,  # omega
     333:  2,  # phi
-    "other": 10,  # unknown
+    "other": 11,  # unknown
 }
 
 dalitz_channels = {
@@ -62,7 +62,8 @@ dalitz_channels = {
     333:  7,  # phi dalitz
     2114:  8,  # delta 0
     2214:  9,  # delta p
-    "other": 10,  # unknown
+    1214: 10,  2124: 10,  # N(1520)
+    "other": 11,  # unknown
 }
 
 rho_channels = {
@@ -113,7 +114,9 @@ ch_list_main = [r'$\rho \rightarrow e^+e^-$',
                 r'$\omega \rightarrow \pi^0 e^+e^-$',
                 r'$\phi \rightarrow \pi^0 e^+e^-$',
                 r'$\Delta^0\rightarrow n e^+e^-$',
-                r'$\Delta^+ \rightarrow p e^+e^-$']
+                r'$\Delta^+ \rightarrow p e^+e^-$',
+                r'$N^*(1520)\rightarrow N e^+e^-$',
+                r'other']
 
 ch_list_rho = [r'$\omega\rightarrow\rho\pi^0\rightarrow e^+e^-\pi^0$',
                r'$\pi^+\pi^-\rightarrow\rho\rightarrow e^+e^-$',
@@ -152,7 +155,7 @@ ch_list_omega = [r'$N^*(1700)\rightarrow\omega N\rightarrow e^+e^-N$',
 ### LINESTYLES ###
 
 line_style_main = ['b-', 'g-', 'r-', 'k--',
-                   'c-', 'c--', 'g--', 'r--', 'y-', 'm--', 'k:']
+                   'c-', 'c--', 'g--', 'r--', 'y-', 'm--', 'b--' ,'k:']
 
 # create (random) linestyle for origin plot
 colors_o = ['b', 'g', 'r', 'c', 'm', 'y']

--- a/test/dileptons/plot_hist.py
+++ b/test/dileptons/plot_hist.py
@@ -120,8 +120,9 @@ def plot(name, bin_factor, ch_list, style_dict, datafile="", cut_legend=""):
     plt.plot(bin_centers_new, sum(hist_new),
              label="all", color='k', linewidth=3)
     for i in range(len(ch_list)):
-        plt.plot(bin_centers_new,
-                 hist_new[i], style_dict["l_style"][i], label=ch_list[i], linewidth=2)
+        if (sum(hist_new[i]) > pow(10,-8)):  # any contributions to channel?
+            plt.plot(bin_centers_new,
+                     hist_new[i], style_dict["l_style"][i], label=ch_list[i], linewidth=2)
 
     # plot data
     if datafile != "":


### PR DESCRIPTION
Extend recognized dilepton sources with (in SMASH-2.1) newly available 
direct N(1520) dilepton Dalitz decay. Not enabled by default. 

In addition, only plot sources that have contributions.