### PR TITLE
Fix plotting bug

### DIFF
--- a/test/angular_distributions/plot_t.py
+++ b/test/angular_distributions/plot_t.py
@@ -61,7 +61,7 @@ with codecs.open(input_file, 'r', encoding='utf-8') as f:
 ncols = len(colnames)
 
 ### (3) read data
-contents = np.loadtxt(input_file, skiprows = 2, unpack=True)
+contents = np.loadtxt(input_file, skiprows = 1, unpack=True)
 t = contents[0]
 
 ### (4) Plot different curves (only positive non-zero values)

--- a/test/angular_distributions/plot_theta.py
+++ b/test/angular_distributions/plot_theta.py
@@ -60,7 +60,7 @@ with codecs.open(input_file, 'r', encoding='utf-8') as f:
 ncols = len(colnames)
 
 ### (3) read data and divide by sin(theta)
-contents = np.loadtxt(input_file, skiprows = 2, unpack=True)
+contents = np.loadtxt(input_file, skiprows = 1, unpack=True)
 theta = contents[0]
 
 for i in range(0,len(theta)):


### PR DESCRIPTION
The first two lines of the files were skipped for plotting, although only the first line contains explanations. The data was nevertheless saved and correctly plotted for comparison
[t.pdf](https://github.com/smash-transport/smash-analysis/files/7710804/t.pdf)
[theta.pdf](https://github.com/smash-transport/smash-analysis/files/7710805/theta.pdf)
.