### PR TITLE
Fix plotting of previous version results for elastic box

### DIFF
--- a/python_scripts/comp_to_prev_version.py
+++ b/python_scripts/comp_to_prev_version.py
@@ -120,9 +120,13 @@ def plot_previous_results(observable, setup, filename, color_list = [], pdg = 0,
                 plt.errorbar(data['x'], data['y'], yerr=data['y_error'],
                              fmt='s', ecolor = 'midnightblue', markeredgecolor= 'midnightblue', markersize = 15, capsize=10, label=label,
                              markerfacecolor= 'white', zorder = 1)
-            elif 'stochastic' in filename:
+            elif 'covariant' in filename:
                 plt.errorbar(data['x'], data['y'], yerr=data['y_error'],
                              fmt='s', ecolor = 'maroon', markeredgecolor= 'maroon', markersize = 15, capsize=10, label=label,
+                             markerfacecolor= 'white', zorder = 1)
+            elif 'stochastic' in filename:
+                plt.errorbar(data['x'], data['y'], yerr=data['y_error'],
+                             fmt='s', ecolor = 'forestgreen', markeredgecolor= 'forestgreen', markersize = 15, capsize=10, label=label,
                              markerfacecolor= 'white', zorder = 1)
 
         elif observable == 'energy_scan':


### PR DESCRIPTION
A small bug prevented the comparison to previous versions for the covariant criterium in the elastic box. This fixes the problem
[scatrate.pdf](https://github.com/smash-transport/smash-analysis/files/7755036/scatrate.pdf)
.