### PR TITLE
Avoid crashes when reading unfinished files

### DIFF
--- a/python_scripts/read_binary_output.py
+++ b/python_scripts/read_binary_output.py
@@ -460,7 +460,10 @@ class BinaryReader:
 
     def read_block(self):
         "Read one output block from SMASH file."
-        return self.__read_block(self.__file)
+        try:
+            return self.__read_block(self.__file)
+        except:
+            return None
 
 
 def count_pdg_in_block(block, pdgid):


### PR DESCRIPTION
It often happens that SMASH produces unfinished runs, for example because
the time ended on the cluster, or SMASH crashed for some reason. Often
information from these unfinished runs is very useful, so it makes sense
for the read-out script to consume all the useful information and stop
at the right moment without crash.

This little modification allows the read-in script to read input file
until the first broken block without crashing.

Signed-off-by: Dmytro Oliinychenko <doliinychenko@lbl.gov>