### PR TITLE
Fix missing Delta reaction curves of previous SMASH version in angular distributions comparison plots

### DIFF
--- a/test/angular_distributions/plot_t.py
+++ b/test/angular_distributions/plot_t.py
@@ -76,7 +76,7 @@ if args.exp_data != '':
 ### (4b) plot data from previous SMASH versions
 if args.comp_prev_version:
     import comp_to_prev_version as cpv
-    processes = ['total','N+N','N+N*','N+\xce\x94','N*+\xce\x94','N+\xce\x94*','\xce\x94+\xce\x94','\xce\x94+\xce\x94*']
+    processes = ['total','N+N','N+N*','N*+Δ','N+Δ','N+Δ*','Δ+Δ','Δ+Δ*']
     cpv.plot_previous_results('angular_distributions', setup, '/t.dat', color_list = colour_coding, process_list = processes)
 
 ### (5) set up axes, labels, etc

--- a/test/angular_distributions/plot_theta.py
+++ b/test/angular_distributions/plot_theta.py
@@ -77,7 +77,7 @@ for i in range(1, ncols):
 ### (4a) plot data from previous SMASH version
 if args.comp_prev_version:
     import comp_to_prev_version as cpv
-    processes = ['total','N+N','N+N*','N+\xce\x94','N*+\xce\x94','N+\xce\x94*','\xce\x94+\xce\x94','\xce\x94+\xce\x94*']
+    processes = ['total','N+N','N+N*','N*+Δ','N+Δ','N+Δ*','Δ+Δ','Δ+Δ*']
     cpv.plot_previous_results('angular_distributions', setup, '/theta.dat', color_list = colour_coding, process_list = processes)
 
 


### PR DESCRIPTION
Hopefully, this should fix the problem in the _angular_distributions_ test plots about the missing curves of the previous SMASH version that refer to a Delta baryon. I tested it with a very small number of events and it seems to work as expected, however I strongly recommend not only to examine the simple changes in the code, but also to test it by redrawing the plots of the recent analysis.