### PR TITLE
Inghirami/improve read binary output

### DIFF
--- a/python_scripts/read_binary_output.py
+++ b/python_scripts/read_binary_output.py
@@ -38,8 +38,8 @@ def _read_binary_block_v2(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart[0])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart[0],
@@ -57,8 +57,8 @@ def _read_binary_block_v2(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -93,8 +93,8 @@ def _read_binary_block_v3(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -113,8 +113,8 @@ def _read_binary_block_v3(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -150,8 +150,8 @@ def _read_binary_block_v4(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -170,8 +170,8 @@ def _read_binary_block_v4(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -207,8 +207,8 @@ def _read_binary_block_v6(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -228,8 +228,8 @@ def _read_binary_block_v6(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -268,8 +268,8 @@ def _read_binary_block_v7(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -289,8 +289,8 @@ def _read_binary_block_v7(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -331,8 +331,8 @@ def _read_binary_block_v4_extended(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -351,8 +351,8 @@ def _read_binary_block_v4_extended(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -388,8 +388,8 @@ def _read_binary_block_v5_extended(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -408,8 +408,8 @@ def _read_binary_block_v5_extended(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -445,8 +445,8 @@ def _read_binary_block_v6_extended(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -466,8 +466,8 @@ def _read_binary_block_v6_extended(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -505,8 +505,8 @@ def _read_binary_block_v7_extended(bfile):
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'p') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -526,8 +526,8 @@ def _read_binary_block_v7_extended(bfile):
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
-            block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') or (block_type == 'f')):
+            tmp_type = bfile.read(1).decode(encoding)
+            if ((tmp_type == 'i') or (tmp_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],

--- a/python_scripts/read_binary_output.py
+++ b/python_scripts/read_binary_output.py
@@ -39,12 +39,12 @@ def _read_binary_block_v2(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart[0])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart[0],
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart[0],
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -58,16 +58,16 @@ def _read_binary_block_v2(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma
+                       }  
             else:
                 return None
         except:
@@ -75,7 +75,7 @@ def _read_binary_block_v2(bfile):
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)
         return {'type': block_type,
-              'nevent': n_event[0]}
+                'nevent': n_event[0]}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -94,12 +94,12 @@ def _read_binary_block_v3(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -114,17 +114,17 @@ def _read_binary_block_v3(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -132,7 +132,7 @@ def _read_binary_block_v3(bfile):
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
-              'nevent': n_event}
+                'nevent': n_event}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -151,12 +151,12 @@ def _read_binary_block_v4(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -171,17 +171,17 @@ def _read_binary_block_v4(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -189,7 +189,7 @@ def _read_binary_block_v4(bfile):
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
-              'nevent': n_event}
+                'nevent': n_event}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -208,12 +208,12 @@ def _read_binary_block_v6(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -229,18 +229,18 @@ def _read_binary_block_v6(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'partial_cross_section': sigma_p,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'partial_cross_section': sigma_p,
+                        'process_type': process
+                       } 
             else:
                 return None
         except:
@@ -249,8 +249,8 @@ def _read_binary_block_v6(bfile):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
         return {'type': block_type,
-              'nevent': n_event,
-              'b' : impact_parameter}
+                'nevent': n_event,
+                'b' : impact_parameter}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -261,7 +261,6 @@ def _read_binary_block_v6(bfile):
 def _read_binary_block_v7(bfile):
     """Read one output block from SMASH binary file."""
     particle_data_type = np.dtype([('r','d',4),('mass','d'),('p','d',4),('pdgid','i4'),('id','i4'),('charge','i4')])
-
     block_type = bfile.read(1).decode(encoding)
     if (block_type == 'p'):
         # got particles block
@@ -269,12 +268,12 @@ def _read_binary_block_v7(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -290,18 +289,18 @@ def _read_binary_block_v7(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'partial_cross_section': sigma_p,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'partial_cross_section': sigma_p,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -311,9 +310,9 @@ def _read_binary_block_v7(bfile):
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
         empty_event = ord(bfile.read(1).decode(encoding))
         return {'type': block_type,
-              'nevent': n_event,
-              'b' : impact_parameter,
-              'empty_event': bool(empty_event)}
+                'nevent': n_event,
+                'b' : impact_parameter,
+                'empty_event': bool(empty_event)}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -332,12 +331,12 @@ def _read_binary_block_v4_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -352,17 +351,17 @@ def _read_binary_block_v4_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -370,7 +369,7 @@ def _read_binary_block_v4_extended(bfile):
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
-              'nevent': n_event}
+                'nevent': n_event}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -389,12 +388,12 @@ def _read_binary_block_v5_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -409,17 +408,17 @@ def _read_binary_block_v5_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -427,7 +426,7 @@ def _read_binary_block_v5_extended(bfile):
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
-              'nevent': n_event}
+                'nevent': n_event}
         # got file end block
     elif (block_type == ''):
         # got eof
@@ -446,12 +445,12 @@ def _read_binary_block_v6_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -467,18 +466,18 @@ def _read_binary_block_v6_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'partial_cross_section': sigma_p,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'partial_cross_section': sigma_p,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -487,8 +486,8 @@ def _read_binary_block_v6_extended(bfile):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
         return {'type': block_type,
-              'nevent': n_event,
-              'b' : impact_parameter}
+                'nevent': n_event,
+                'b' : impact_parameter}
     elif (block_type == ''):
         # got eof
         return
@@ -506,12 +505,12 @@ def _read_binary_block_v7_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'p') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'npart': npart,
-                         'part': particles
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'npart': npart,
+                        'part': particles
+                       }
             else:
                 return None
         except:
@@ -527,18 +526,18 @@ def _read_binary_block_v7_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             tmp_type = bfile.read(1).decode(encoding)
-            if ((tmp_type == 'i') or (tmp_type == 'f')):
-                 bfile.seek(-1, 1)
-                 return {'type': block_type,
-                         'nin': n_inout[0],
-                         'nout': n_inout[1],
-                         'incoming': incoming,
-                         'outgoing': outgoing,
-                         'density': rho,
-                         'total_cross_section': sigma,
-                         'partial_cross_section': sigma_p,
-                         'process_type': process
-                        }
+            if ((tmp_type == 'p') or (tmp_type == 'f') or (tmp_type == 'i')):
+                bfile.seek(-1, 1)
+                return {'type': block_type,
+                        'nin': n_inout[0],
+                        'nout': n_inout[1],
+                        'incoming': incoming,
+                        'outgoing': outgoing,
+                        'density': rho,
+                        'total_cross_section': sigma,
+                        'partial_cross_section': sigma_p,
+                        'process_type': process
+                       }
             else:
                 return None
         except:
@@ -548,9 +547,9 @@ def _read_binary_block_v7_extended(bfile):
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
         empty_event = np.fromfile(bfile, dtype='B', count=1)[0]
         return {'type': block_type,
-              'nevent': n_event,
-              'b' : impact_parameter,
-              'empty_event': bool(empty_event)}
+                'nevent': n_event,
+                'b' : impact_parameter,
+                'empty_event': bool(empty_event)}
     elif (block_type == ''):
         # got eof
         return

--- a/python_scripts/read_binary_output.py
+++ b/python_scripts/read_binary_output.py
@@ -37,9 +37,18 @@ def _read_binary_block_v2(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart[0])
-        return {'type': block_type,
-                'npart': npart[0],
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart[0],
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout = np.fromfile(bfile, dtype='i4', count=2)
@@ -47,14 +56,22 @@ def _read_binary_block_v2(bfile):
         sigma = np.fromfile(bfile, dtype='d', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma
-               }
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)
         return {'type': block_type,
@@ -75,9 +92,18 @@ def _read_binary_block_v3(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -86,14 +112,23 @@ def _read_binary_block_v3(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
@@ -114,9 +149,18 @@ def _read_binary_block_v4(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -125,14 +169,23 @@ def _read_binary_block_v4(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
@@ -153,9 +206,18 @@ def _read_binary_block_v6(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -165,15 +227,24 @@ def _read_binary_block_v6(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'partial_cross_section': sigma_p,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'partial_cross_section': sigma_p,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
@@ -196,9 +267,18 @@ def _read_binary_block_v7(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -208,15 +288,24 @@ def _read_binary_block_v7(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'partial_cross_section': sigma_p,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'partial_cross_section': sigma_p,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
@@ -241,9 +330,18 @@ def _read_binary_block_v4_extended(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -252,14 +350,23 @@ def _read_binary_block_v4_extended(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
@@ -280,9 +387,18 @@ def _read_binary_block_v5_extended(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -291,14 +407,23 @@ def _read_binary_block_v5_extended(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         return {'type': block_type,
@@ -319,9 +444,18 @@ def _read_binary_block_v6_extended(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -331,15 +465,24 @@ def _read_binary_block_v6_extended(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'partial_cross_section': sigma_p,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'partial_cross_section': sigma_p,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]
@@ -361,9 +504,18 @@ def _read_binary_block_v7_extended(bfile):
         # got particles block
         npart = np.fromfile(bfile, dtype='i4', count=1)[0]
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
-        return {'type': block_type,
-                'npart': npart,
-                'part': particles}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'p') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'npart': npart,
+                         'part': particles
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'i'):
         # got interaction block
         n_inout  = np.fromfile(bfile, dtype='i4', count=2)
@@ -373,15 +525,24 @@ def _read_binary_block_v7_extended(bfile):
         process  = np.fromfile(bfile, dtype='i4', count=1)[0]
         incoming = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[0])
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
-        return {'type': block_type,
-                'nin': n_inout[0],
-                'nout': n_inout[1],
-                'incoming': incoming,
-                'outgoing': outgoing,
-                'density': rho,
-                'total_cross_section': sigma,
-                'partial_cross_section': sigma_p,
-                'process_type': process}
+        try:
+            block_type = bfile.read(1).decode(encoding)
+            if ((block_type == 'i') || (block_type == 'f')):
+                 bfile.seek(-1, 1)
+                 return {'type': block_type,
+                         'nin': n_inout[0],
+                         'nout': n_inout[1],
+                         'incoming': incoming,
+                         'outgoing': outgoing,
+                         'density': rho,
+                         'total_cross_section': sigma,
+                         'partial_cross_section': sigma_p,
+                         'process_type': process
+                        }
+            else:
+                return None
+        except:
+                return None
     elif (block_type == 'f'):
         n_event = np.fromfile(bfile, dtype='i4', count=1)[0]
         impact_parameter = np.fromfile(bfile, dtype='d',  count=1)[0]

--- a/python_scripts/read_binary_output.py
+++ b/python_scripts/read_binary_output.py
@@ -39,7 +39,7 @@ def _read_binary_block_v2(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart[0])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart[0],
@@ -58,7 +58,7 @@ def _read_binary_block_v2(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -94,7 +94,7 @@ def _read_binary_block_v3(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -114,7 +114,7 @@ def _read_binary_block_v3(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -151,7 +151,7 @@ def _read_binary_block_v4(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -171,7 +171,7 @@ def _read_binary_block_v4(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -208,7 +208,7 @@ def _read_binary_block_v6(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -229,7 +229,7 @@ def _read_binary_block_v6(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -269,7 +269,7 @@ def _read_binary_block_v7(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -290,7 +290,7 @@ def _read_binary_block_v7(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -332,7 +332,7 @@ def _read_binary_block_v4_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -352,7 +352,7 @@ def _read_binary_block_v4_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -389,7 +389,7 @@ def _read_binary_block_v5_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -409,7 +409,7 @@ def _read_binary_block_v5_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -446,7 +446,7 @@ def _read_binary_block_v6_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -467,7 +467,7 @@ def _read_binary_block_v6_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],
@@ -506,7 +506,7 @@ def _read_binary_block_v7_extended(bfile):
         particles = np.fromfile(bfile, dtype=particle_data_type, count=npart)
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'p') || (block_type == 'f')):
+            if ((block_type == 'p') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'npart': npart,
@@ -527,7 +527,7 @@ def _read_binary_block_v7_extended(bfile):
         outgoing = np.fromfile(bfile, dtype=particle_data_type, count=n_inout[1])
         try:
             block_type = bfile.read(1).decode(encoding)
-            if ((block_type == 'i') || (block_type == 'f')):
+            if ((block_type == 'i') or (block_type == 'f')):
                  bfile.seek(-1, 1)
                  return {'type': block_type,
                          'nin': n_inout[0],


### PR DESCRIPTION
With this modification the script _read_binary_output.py_ accepts a block only if it is able to retrieve a recognizable label for the next one, thus improving the reliability of data in the case of a premature ending of SMASH (at the price of a tiny larger execution time).

https://theory.gsi.de/~ginghir/tmp_test_data/data_for_testing.zip provides an example in which this modification might be useful.
The data refer to a SMASH-2.1 run manually aborted before its natural end.
If one tries to work with the data using ` ipython` with something like (the path will be different, of course):
```
In [1]: from read_binary_output import *                                                         
In [2]: with BinaryReader("/home/g/data_for_testing/particles_binary.bin.unfinished") as reader: 
   ...:   smash_version = reader.smash_version 
   ...:   for b in reader: 
   ...:       print(b['type']) 
   ...:       if(b['type']=='p'): 
   ...:           print(str(get_block_px(b))) 
   ...:   
   ```
with the current version one gets (I report only the final lines):
```
p
-4.440892098500626e-15
p
-1.1157297308272973e-11
p
-1.1161738200371474e-11
p
0.742975483157231
```
while, with the modified version:
```
p
-4.440892098500626e-15
p
-1.1157297308272973e-11
p
-1.1161738200371474e-11
```
i.e. the final incomplete block with corrupted double values is discarded.

The proposed changes are conceptually very simple, however, since the script deals with many different versions of the binary format that have not been tested after the modification, I recommend the reviewer(s) to carefully check for possible undetected typos.
Since this topic has been discussed also in https://github.com/smash-transport/smash-analysis/pull/45 , I mention here @akschaefer @doliinychenko @AxelKrypton @stdnmr .