### PR TITLE
Left over python2 invocations updated to python3

### DIFF
--- a/cmake/FloatMath.cmake
+++ b/cmake/FloatMath.cmake
@@ -1,5 +1,5 @@
 function(float_math VAR expr)
-    execute_process(COMMAND "python3" "-Sc" "print ${expr}"
+    execute_process(COMMAND "python3" "-Sc" "print(${expr})"
                     OUTPUT_VARIABLE output
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     set(${VAR} ${output} PARENT_SCOPE)

--- a/cmake/FloatMath.cmake
+++ b/cmake/FloatMath.cmake
@@ -1,5 +1,5 @@
 function(float_math VAR expr)
-    execute_process(COMMAND "python2" "-Sc" "print ${expr}"
+    execute_process(COMMAND "python3" "-Sc" "print ${expr}"
                     OUTPUT_VARIABLE output
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     set(${VAR} ${output} PARENT_SCOPE)

--- a/test/cross_sections/loewe_analysis/main_cross_section_script.bash
+++ b/test/cross_sections/loewe_analysis/main_cross_section_script.bash
@@ -18,7 +18,7 @@ xsectionscript=$(readlink -f ${xsectionscript})
 export PYTHONPATH=$PYTHONPATH:$smashpython
 
 # find the path to python for this system
-pythonpath=$(which python2)
+pythonpath=$(which python3)
 # update the python path in scripts
 # replace only the first occurrence of shebang
 # since we're dealing with paths with '/'s, let's use @ as delimiter for sed


### PR DESCRIPTION
This PR upgrades two `python2` invocations to `python3`.
Hopefully now none should be left.
This might solve also Issue #53 .

I propose @nilssass as the reviewer, but I also mention @AxelKrypton for a more expert overview (even if actually the modifications are trivial).