### PR TITLE
Change to python3 changes directory names in FOPI_pions tests

### DIFF
--- a/test/FOPI_pions/CMakeLists.txt
+++ b/test/FOPI_pions/CMakeLists.txt
@@ -41,9 +41,9 @@ function(run_one_energy
   set(FOPI_energies ${FOPI_energies};${target} PARENT_SCOPE)
 endfunction()
 
-foreach(n RANGE 0 11)                  # loop over energy
-	float_math(E "round(0.4 + ${n}*0.1, 1)")  # calc. energy
-  run_one_energy(${E})
+foreach(n RANGE 0 11)                         # loop over energy
+    float_math(E "round(0.4 + ${n}*0.1, 1)")  # calc. energy
+    run_one_energy(${E})
 endforeach()
 
 # analysis

--- a/test/FOPI_pions/CMakeLists.txt
+++ b/test/FOPI_pions/CMakeLists.txt
@@ -42,7 +42,7 @@ function(run_one_energy
 endfunction()
 
 foreach(n RANGE 0 11)                  # loop over energy
-  float_math(E "0.4 + ${n}*0.1")  # calc. energy
+	float_math(E "round(0.4 + ${n}*0.1, 1)")  # calc. energy
   run_one_energy(${E})
 endforeach()
 


### PR DESCRIPTION
After change to python3, the directory names in `/smash-analysis/build/test/FOPI_pions` get too many decimal points:

```
-- Configuring FOPI_pions/0.4.
-- Configuring FOPI_pions/0.5.
-- Configuring FOPI_pions/0.6000000000000001.
-- Configuring FOPI_pions/0.7000000000000001.
-- Configuring FOPI_pions/0.8.
-- Configuring FOPI_pions/0.9.
-- Configuring FOPI_pions/1.0.
-- Configuring FOPI_pions/1.1.
-- Configuring FOPI_pions/1.2000000000000002.
```

This PR adds a 'round' command in `/smash-analysis/test/FOPI_pions/CMakeLists.txt` to round the energy to one decimal place.