### PR TITLE
Fix pT spectra old result scaling

### DIFF
--- a/python_scripts/comp_to_prev_version.py
+++ b/python_scripts/comp_to_prev_version.py
@@ -138,7 +138,7 @@ def plot_previous_results(observable, setup, filename, color_list = [], pdg = 0,
                 plt.plot(data['y'], data[str(energy)], color = plot_color,
                          linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
             elif 'ptspectra' in filename:
-                plt.plot(data['pt'], data[str(energy)], color = plot_color,
+                plt.plot(data['pt'], data[str(energy)]* 10**scaling_counter, color = plot_color,
                          linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
 
             else:
@@ -156,7 +156,7 @@ def plot_previous_results(observable, setup, filename, color_list = [], pdg = 0,
                 plt.plot(data['y'], data[str(energy)], color = plot_color,
                          linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
             elif 'ptspectra' in filename:
-                plt.plot(data['pt'], data[str(energy)], color = plot_color,
+                plt.plot(data['pt'], data[str(energy)]* 10**scaling_counter, color = plot_color,
                          linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
 
             else:

--- a/python_scripts/comp_to_prev_version.py
+++ b/python_scripts/comp_to_prev_version.py
@@ -138,8 +138,9 @@ def plot_previous_results(observable, setup, filename, color_list = [], pdg = 0,
                 plt.plot(data['y'], data[str(energy)], color = plot_color,
                          linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
             elif 'ptspectra' in filename:
-                plt.plot(data['pt'], data[str(energy)]* 10**scaling_counter, color = plot_color,
-                         linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
+                plt.plot(data['pt'], data[str(energy)] * 10**scaling_counter,
+                         color = plot_color, linestyle = '-', linewidth = 10,
+                         zorder = 1, alpha = 0.15)
 
             else:
                 plt.plot(data['sqrt_s'], data[str(pdg)], plot_style,
@@ -156,8 +157,9 @@ def plot_previous_results(observable, setup, filename, color_list = [], pdg = 0,
                 plt.plot(data['y'], data[str(energy)], color = plot_color,
                          linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
             elif 'ptspectra' in filename:
-                plt.plot(data['pt'], data[str(energy)]* 10**scaling_counter, color = plot_color,
-                         linestyle = '-', linewidth = 10, zorder = 1, alpha = 0.15)
+                plt.plot(data['pt'], data[str(energy)] * 10**scaling_counter,
+                         color = plot_color, linestyle = '-', linewidth = 10,
+                         zorder = 1, alpha = 0.15)
 
             else:
                 plt.plot(data['sqrt_s'], data[str(pdg)], plot_style,


### PR DESCRIPTION
This is the fix for #55 . Only a factor in the comparison to old results was missing.
This PR only modifies the display of old results, therefore here a comparison to 
[before ](https://github.com/smash-transport/smash-analysis/files/8520560/ptspectra_AuAuPbPb_RHIC_LHC_211.pdf) and [after](https://github.com/smash-transport/smash-analysis/files/8520569/ptspectra_AuAuPbPb_RHIC_LHC_211.pdf) the changes with dummy simulation data.