### PR TITLE
Upgrade to matplotlib 3.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 find_python_module(numpy VERSION 1.17.4 REQUIRED)
 find_python_module(scipy VERSION 1.3.3 REQUIRED)
-find_python_module(matplotlib VERSION 3.1.2 REQUIRED)
+find_python_module(matplotlib VERSION 3.3.1 REQUIRED)
 find_python_module(argparse VERSION 1.1 REQUIRED)
 find_python_module(yaml VERSION 5.3.1 REQUIRED)
 find_python_module(pandas VERSION 0.25.3 REQUIRED)
@@ -83,7 +83,7 @@ add_subdirectory(test/energy_scan)
 if(SAMPLED_LISTS)
   # 4) afterburner test
   add_subdirectory(test/afterburner)
-else() 
-  message(STATUS "No path for download path for sampled particle lists was given, afterburner target not available. Specify via 
+else()
+  message(STATUS "No path for download path for sampled particle lists was given, afterburner target not available. Specify via
                     cmake .. -DSAMPLED_LISTS=/link/to/lists")
 endif(SAMPLED_LISTS)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Furthermore, Python 3.8.x is necessary with the following modules:
 
 - [numpy](www.numpy.org) version &ge; 1.17.4
 - [scipy](www.scipy.org) version &ge; 1.3.3
-- [matplotlib](www.matplotlib.org) version &ge; 3.1.2
+- [matplotlib](www.matplotlib.org) version &ge; 3.3.1
 - [argparse](https://docs.python.org/3/library/argparse.html) version &ge; 1.1
 - [pyyaml](www.pyyaml.org) version &ge; 5.3.1
 - [pandas](www.pandas.pydata.org) version &ge; 0.25.3
@@ -152,9 +152,9 @@ Note, that all dilepton data files generated during the SMASH run are
 immediately removed once they have been analyzed, as they are exceptionally
 large.   
 
-In case of the afterburner target, the SMASH-analysis suite has to be compiled 
+In case of the afterburner target, the SMASH-analysis suite has to be compiled
 with an additional argument `-DSAMPLED_LISTS`. This has to be an URL from where
-the sampled lists as an input for the afterburner target can be downloaded. 
+the sampled lists as an input for the afterburner target can be downloaded.
 Without this argument, the target is not available. The URL for the lists used
 in the latest report is `http://theory.gsi.de/~smash/data/sampled_lists/`.
 

--- a/test/densities/plot_2d_density.py
+++ b/test/densities/plot_2d_density.py
@@ -47,7 +47,7 @@ for ax in axs.flat:
     tstep = times[i]
     rho_grid = Grid[i].reshape(dim_grid, dim_grid)
     ax.set_title('t = {} fm'.format(tstep), fontsize=15)
-    im = ax.imshow(rho_grid, cmap='GnBu_r', interpolation='nearest', norm=norm, vmin = norm_min, vmax = norm_max)
+    im = ax.imshow(rho_grid, cmap='GnBu_r', interpolation='nearest', norm=norm)
     ax.set_xlabel('x', fontsize=18)
     if i > 0: ax.set_yticklabels([])
     else: ax.set_ylabel('y', fontsize=18)


### PR DESCRIPTION
In order to be executable with latest matplotlib, PR #59 also changed the keyword `nonposy` to `nonpositive`, as otherwise the analysis suite cannot be executed anymore. As a consequence, the minimum version of matplotlib for the analysis suite is now 3.3.1 . Minor changes are needed in order to adapt to the new version.
On a first glance, no changes in the appearance of the plots occured.