### PR TITLE
Ngoetz/watermark improvement

### DIFF
--- a/test/energy_scan/mult_and_spectra_plotter.py
+++ b/test/energy_scan/mult_and_spectra_plotter.py
@@ -656,7 +656,7 @@ def plotting(data1, data2, config_file, smash_code_version, output_folder):
                                 filename_prev = quantity + '_' + colliding_system.replace('/', '') + str(pdg)
                                 prev_SMASH_version =  cpv.plot_previous_results('afterburner', '', filename_prev + '.txt',
                                                   energy = energy, plot_color = 'midnightblue', scaling_counter = 0)
-                                plt.text(0.5, 0.5, 'SMASH-vHLLE-hybrid', fontsize=40, color='gray', ha='right', va='bottom', alpha=0.5, transform=plt.gca().transAxes)
+                                plt.text(0.5, 0.5, smash_code_version+'-vHLLE-hybrid', fontsize=40, color='gray', ha='right', va='bottom', alpha=0.5, transform=plt.gca().transAxes)
                             plt.plot(1,0.0, linestyle = '-', linewidth = 10, zorder = 1,
                                     color='dimgrey', label=prev_SMASH_version, alpha = 0.2)
                         plt.legend(loc= 'upper right', title = '$\sqrt{s} \ $ [GeV] =' , ncol = 1, fontsize = 26)

--- a/test/energy_scan/mult_and_spectra_plotter.py
+++ b/test/energy_scan/mult_and_spectra_plotter.py
@@ -458,7 +458,7 @@ def plotting(data1, data2, config_file, smash_code_version, output_folder):
                      plt.yscale('log', nonpositive='clip')
             if( quantity in ['total_multiplicity', 'midrapidity_yield', 'meanmt0_midrapidity', 'meanpt_midrapidity']  and 'afterburner' in colliding_systems):
                 plt.xlim([190,5100])
-                plt.text(0.5, 0.5, 'SMASH-vHLLE-hybrid', fontsize=40, color='gray', ha='right', va='bottom', alpha=0.5, transform=plt.gca().transAxes)
+                plt.text(0.5, 0.5, smash_code_version+'-vHLLE-hybrid', fontsize=40, color='gray', ha='right', va='bottom', alpha=0.5, transform=plt.gca().transAxes)
             hadron_name = sb.pdg_to_name(pdg_abs, config_file)
             antihadron_name = sb.pdg_to_name(-pdg_abs, config_file)
             plot_title = hadron_name


### PR DESCRIPTION
This small PR changes  the watermark for afterburner plots from 'SMASH-vHLLE-hybrid' to 'SMASH-version-vHLLE-hybrid'.
[Example](https://github.com/smash-transport/smash-analysis/files/8605026/total_multiplicity211.pdf)