### PR TITLE
Comment about maximum impact parameter

### DIFF
--- a/test/cross_sections/config.yaml
+++ b/test/cross_sections/config.yaml
@@ -44,7 +44,7 @@ Modi:
 
         Impact:
             Sample: uniform
-            Max: 2.5
+            Max: 2.5  # If this value is changed, "bmax" in geometrical_cross_section.py must be changed accordingly.
 
         # Collision energy (E_LAB, P_LAB, SQRTSNN).
         #Sqrtsnn: XXX


### PR DESCRIPTION
Changing it breaks the analysis, since `bmax` is set explicitly in `geometrical_cross_section.py`. It would be nice to fix this in the future, perhaps taking the value from the config file.