### PR TITLE
Update MutableSet module

### DIFF
--- a/python_scripts/ordered_default_dict.py
+++ b/python_scripts/ordered_default_dict.py
@@ -1,4 +1,4 @@
-from collections import MutableSet
+from collections.abc import MutableSet
 
 class OrderedSet(MutableSet):
     def __init__(self, iterable=None):


### PR DESCRIPTION
From `collections` to `collections.abc` module (since python3.3 is lower than version 3.8, which we require)

@AxelKrypton just to be quick :)